### PR TITLE
Make VOMS organization a passed in property

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg; \
     curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo;
 
-RUN yum install osg-ca-certs voms voms-clients wlcg-voms-atlas fetch-crl -y
+RUN yum install osg-ca-certs voms voms-clients wlcg-voms-atlas wlcg-voms-cms fetch-crl -y
 
 # We need python3 which is not part of the Rucio docker image
 RUN yum install -y centos-release-scl && \
@@ -45,5 +45,5 @@ RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
 
 ENV X509_USER_PROXY /etc/grid-security/x509up
 
-CMD sh -c "python x509_updater.py"
+CMD sh -c "python x509_updater.py --voms $VOMS"
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 
+# X509 Proxy Generator
+This image passes a users grid cert and key to the VOMS Proxy server to generate
+an X509 proxy which is published into the cluster as a kubernetes secret.
+
+It accepts as runtime parameter the VOMS organization to use for validating
+the user. It also can be run inside docker (without a kubernetes cluster) for
+testing.
+
 To start docker container: 
 ```bash
-docker run --rm \
+docker run --rm -it \
+    -e VOMS=atlas \
     --mount type=bind,source=$HOME/.globus,readonly,target=/etc/grid-certs \
     --mount type=bind,source="$(pwd)"/secrets/secrets.txt,target=/servicex/secrets.txt \
     --mount type=volume,source=x509,target=/etc/grid-security \
-    --name=x509-secrets x509-secrets:latest 
+    --name=x509-secrets sslhep/x509-secrets:develop
 ```
+
+The environment var `VOMS` can be set to CMS if you wish to authenticate against 
+that experiment.


### PR DESCRIPTION
# Problem
The call to `voms-proxy-init` had a hardcoded Atlas reference. This needs to be a passed-in value to support CMS

Partial fix to ServiceX [Issue 97](https://github.com/ssl-hep/ServiceX/issues/97)
# Approach
1. Added proper command line arguments to `X509_updater.py` script
2. Updated the Dockerfile to 
 a. Install the cms voms proxy servers
 b. Accept an environment variable for the VOMS organization
3. Fixed a nuisance exception that was being reported in the log