### PR TITLE
Update paths in updater to match cluster-wide certs secret

### DIFF
--- a/x509_updater.py
+++ b/x509_updater.py
@@ -65,7 +65,7 @@ myCmd = """
  voms-proxy-init --pwstdin -key /etc/grid-certs/userkey.pem \
                   -cert /etc/grid-certs/usercert.pem \
                   --voms=%s \
-                  <  /servicex/secrets.txt
+                  <  /etc/grid-certs-ro/passphrase
                   """
 os.system(myCmd % args.voms)
 f = "/etc/grid-security/x509up"
@@ -91,12 +91,13 @@ while True:
             if secret_created:
                 client.CoreV1Api().patch_namespaced_secret(name=secret_name,
                                                            namespace=pod_namespace, body=secret)
+                print("Updated proxy cert in  %s" % secret_name)
+
             else:
                 client.CoreV1Api().create_namespaced_secret(namespace=pod_namespace, body=secret)
+                print("Created Secret %s" % secret_name)
                 secret_created = True
 
-    # Update crls
-    os.system("/usr/sbin/fetch-crl")
     time.sleep(6*60*60)
 
 


### PR DESCRIPTION
# Problem
The current way of providing grid certs and passphrase to the x509 proxy requires putting them into the helm chart's `values.yaml` - this works, but is not very secure.
Partial solution to [ServiceX Issue 80](https://github.com/ssl-hep/ServiceX/issues/80)

# Approach
The new servicex-cli has a command for putting the certs and passphrase into a secret. The helm chart will mount those files as `/etc/grid-certs-ro/`. This was a slight change from the previous use of config map for the certs and a secret for the passphrase.

In this PR, we simply move the reference to where the passphrase is kept. We also clean up some messages.

Finally, the x509 proxy service had a legacy call to `/usr/sbin/fetch-crl` which doesn't do anything for us, and is often a source of failure 