### PR TITLE
Freeze dependencies for v1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-kubernetes
+kubernetes==11.0.0


### PR DESCRIPTION
Partially fulfills #92 . All libraries in requirements.txt are fixed to the minor version number
