### PR TITLE
Retain root user for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM rucio/rucio-clients:latest
 
+USER root
+
 # Create app directory
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The new Rucio docker image switches from root user to a user called `user` this breaks the X509_secrets docker file