### PR TITLE
Remove hard-coded location for proxy

### DIFF
--- a/x509_updater.py
+++ b/x509_updater.py
@@ -68,7 +68,7 @@ myCmd = """
                   <  /etc/grid-certs-ro/passphrase
                   """
 os.system(myCmd % args.voms)
-f = "/etc/grid-security/x509up"
+f = "/tmp/x509up"
 
 if not secret_name:
     sys.exit(0)


### PR DESCRIPTION
This allows the proxy location to be configurable via the env var, which should let the image owner run as user (in an openshift environment, for example).