### PR TITLE
Change X509_USER_PROXY to match python script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . .
 # build  
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
 
-ENV X509_USER_PROXY /etc/grid-security/x509up
+ENV X509_USER_PROXY /tmp/x509up
 
 CMD sh -c "python3 x509_updater.py --voms $VOMS"
 


### PR DESCRIPTION
# Problem
The X-509 Secret service dies upon startup

Fixes #16 

# Approach
The script was reading the proxy file from `/tmp/x509up` however the Dockerfile still had `X509_USER_PROXY` set to the old location.

Updated Dockerfile to match the script and it starts correctly now